### PR TITLE
feat: enable dark mode site-wide

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" className="dark">
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >


### PR DESCRIPTION
Add dark class to html element to activate dark mode CSS variables. All components using Tailwind and shadcn/ui will automatically adapt to dark mode styling.

Fixes #8