### PR TITLE
fix: use shadcn buttons for sign in and sign up

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
   SignedOut,
   UserButton,
 } from "@clerk/nextjs";
+import { Button } from "@/components/ui/button";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -38,8 +39,12 @@ export default function RootLayout({
         >
           <header className="flex justify-end items-center gap-4 p-4">
             <SignedOut>
-              <SignInButton mode="modal" />
-              <SignUpButton mode="modal" />
+              <SignInButton mode="modal">
+                <Button variant="outline">Sign In</Button>
+              </SignInButton>
+              <SignUpButton mode="modal">
+                <Button>Sign Up</Button>
+              </SignUpButton>
             </SignedOut>
             <SignedIn>
               <UserButton />


### PR DESCRIPTION
Replace Clerk's default SignInButton and SignUpButton components with shadcn Button components. The Sign In button uses the outline variant and the Sign Up button uses the default variant for better visual hierarchy.

Fixes #7